### PR TITLE
Logout user before remote request.

### DIFF
--- a/inc/CLI_Command.php
+++ b/inc/CLI_Command.php
@@ -16,6 +16,8 @@ class CLI_Command extends WP_CLI_Command {
 	 *     Success: The OPcache was successfully cleared!
 	 */
 	public function clear() {
+		wp_set_current_user( 0 );
+
 		$response = wp_remote_post(
 			add_query_arg( [
 				'opcache_action' => 'clear-opcache',
@@ -67,6 +69,8 @@ class CLI_Command extends WP_CLI_Command {
 	 *     Success: The OPcache was successfully invalidated for foo/bar.php.
 	 */
 	public function invalidate( array $args, array $assoc_args ) {
+		wp_set_current_user( 0 );
+
 		$script = $args['0'];
 		$response = wp_remote_post(
 			add_query_arg( [

--- a/wp-cli-clear-opcache.php
+++ b/wp-cli-clear-opcache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-CLI Clear OPcache
  * Plugin URI:  https://github.com/wearerequired/wp-cli-clear-opcache
  * Description: Use WP-CLI to clear the OPcache for a site via HTTP.
- * Version:     1.0.1
+ * Version:     1.0.2
  * Author:      required
  * Author URI:  https://required.com
  * License:     GPL v2.0+


### PR DESCRIPTION
If we have `user:` parameter specified in `wp-cli.yml`, every wp cli command is runs under the specified user. So `wp_create_nonce( 'clear-opcache' )` will create nonce code for the logged-in user. But when then it will be checked with `wp_verify_nonce()` it will check nonce from query parameter for not-logged environment and the check will never be passed.